### PR TITLE
add support for LAZ by piping through laszip

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,23 @@ Currently unregistered, install using
 Pkg.clone("https://github.com/visr/LasIO.jl.git")
 ```
 
-This is a pure Julia alternative to [LibLAS.jl](https://github.com/visr/LibLAS.jl) or [Laszip.jl](https://github.com/joa-quim/Laszip.jl). Unlike those it does not support the compressed LAZ format. Furthermore currently only LAS versions 1.1 - 1.3 and point formats 0 - 3 are supported.
+This is a pure Julia alternative to [LibLAS.jl](https://github.com/visr/LibLAS.jl) or [Laszip.jl](https://github.com/joa-quim/Laszip.jl). Currently only LAS versions 1.1 - 1.3 and point formats 0 - 3 are supported. For LAZ support see below.
 
 If the file fits into memory, it can be loaded using
 
 ```julia
-using FileIO
-using LasIO
+using FileIO, LasIO
 header, points = load("test.las")
 ```
 
 where `header` is of type `LasHeader`, and, if it is point format 3, `points` is a `Vector{LasPoint3}`. `LasPoint3` is an immutable that directly corresponds to the binary data in the LAS file. Use functions like `xcoord(p::LasPoint, header::LasHeader)` to take out the desired items in the point.
 
 See `test/runtests.jl` for other usages.
+
+## LAZ support
+The compressed LAZ format is supported, but requires the user to make sure the `laszip` executable can be found in the PATH. LAZ files are piped through `laszip` to provide reading and writing capability. `laszip` is not distributed with this package. One way to get it is to download `LAStools` from https://rapidlasso.com/. The LAStools ZIP file already contains `laszip.exe` for Windows, for Linux or Mac it needs to be compiled first. When this is done this should work just like with LAS:
+
+```julia
+using FileIO, LasIO
+header, points = load("test.laz")
+```

--- a/src/LasIO.jl
+++ b/src/LasIO.jl
@@ -56,6 +56,7 @@ function __init__()
     # these should eventually go in
     # https://github.com/JuliaIO/FileIO.jl/blob/master/src/registry.jl
     add_format(format"LAS", "LASF", ".las", [:LasIO])
+    add_format(format"LAZ", (), ".laz", [:LasIO])
 end
 
 end # module

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -38,7 +38,7 @@ end
 
 function load(f::File{format"LAZ"})
     # read las from laszip, which decompresses to stdout
-    open(`laszip -olas -stdout -i "$(filename(f))"`) do s
+    open(`laszip -olas -stdout -i $(filename(f))`) do s
         load(s)
     end
 end
@@ -80,7 +80,7 @@ end
 
 function save(f::File{format"LAZ"}, header::LasHeader, pointdata::Vector{T}) where T <: LasPoint
     # pipes las to laszip to write laz
-    open(`laszip -olaz -stdin -o "$(filename(f))"`, "w") do s
+    open(`laszip -olaz -stdin -o $(filename(f))`, "w") do s
         savebuf(s, header, pointdata)
     end
 end
@@ -106,9 +106,7 @@ function savebuf(s::IO, header::LasHeader, pointdata::Vector{T}) where T <: LasP
     # write points
     for (i, p) in enumerate(pointdata)
         write(buf, p)
-        if rem(i, npoints_buffered) == 0
-            write(s, take!(buf))
-        elseif i == n
+        if rem(i, npoints_buffered) == 0 || i == n
             write(s, take!(buf))
         end
     end

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -14,17 +14,19 @@ function pointformat(header::LasHeader)
     end
 end
 
+# skip the LAS file's magic four bytes, "LASF"
+skiplasf(s::Union{Stream{format"LAS"}, Stream{format"LAZ"}, IO}) = read(s, UInt32)
+
 function load(f::File{format"LAS"})
     open(f) do s
-        skipmagic(s) # skip over the magic bytes
         load(s)
     end
 end
 
-function load(s::Stream{format"LAS"})
+function load(s::Union{Stream{format"LAS"}, Pipe})
+    skiplasf(s)
     header = read(s, LasHeader)
 
-    seek(s, header.data_offset)
     n = header.records_count
     pointtype = pointformat(header)
     pointdata = Vector{pointtype}(n)
@@ -34,13 +36,22 @@ function load(s::Stream{format"LAS"})
     header, pointdata
 end
 
+function load(f::File{format"LAZ"})
+    # read las from laszip, which decompresses to stdout
+    open(`laszip -olas -stdout -i "$(filename(f))"`) do s
+        load(s)
+    end
+end
+
 function read_header(f::AbstractString)
     open(f) do s
+        skiplasf(s)
         read(s, LasHeader)
     end
 end
 
 function read_header(s::IO)
+    skiplasf(s)
     read(s, LasHeader)
 end
 
@@ -60,11 +71,45 @@ function save(s::Stream{format"LAS"}, header::LasHeader, pointdata::Vector{T}) w
     # write header
     write(s, magic(format"LAS"))
     write(s, header)
-    bytes_togo = header.data_offset - position(s)
-    @assert bytes_togo == 0
 
     # write points
-    for i = 1:n
-        write(s, pointdata[i])
+    for p in pointdata
+        write(s, p)
+    end
+end
+
+function save(f::File{format"LAZ"}, header::LasHeader, pointdata::Vector{T}) where T <: LasPoint
+    # pipes las to laszip to write laz
+    open(`laszip -olaz -stdin -o "$(filename(f))"`, "w") do s
+        savebuf(s, header, pointdata)
+    end
+end
+
+# Uses a buffered write to the stream.
+# For saving to LAS this does not increase speed,
+# but it speeds up a lot when the result is piped to laszip.
+function savebuf(s::IO, header::LasHeader, pointdata::Vector{T}) where T <: LasPoint
+    # checks
+    header_n = header.records_count
+    n = length(pointdata)
+    msg = "number of records in header ($header_n) does not match data length ($n)"
+    @assert header_n == n msg
+
+    # write header
+    write(s, magic(format"LAS"))
+    write(s, header)
+
+    # 2048 points seemed to be an optimum for the libLAS_1.2.las testfile
+    npoints_buffered = 2048
+    bufsize = header.data_record_length * npoints_buffered
+    buf = IOBuffer(bufsize)
+    # write points
+    for (i, p) in enumerate(pointdata)
+        write(buf, p)
+        if rem(i, npoints_buffered) == 0
+            write(s, take!(buf))
+        elseif i == n
+            write(s, take!(buf))
+        end
     end
 end

--- a/src/vlrs.jl
+++ b/src/vlrs.jl
@@ -44,3 +44,7 @@ function Base.write(io::IO, vlr::LasVariableLengthRecord, extended::Bool=false)
     write(io, vlr.data)
     nothing
 end
+
+# size of a VLR in bytes
+# assumes it is not extended VLR
+Base.sizeof(vlr::LasVariableLengthRecord) = 54 + length(vlr.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,6 +35,8 @@ end
 
 # reading point by point
 open(testfile) do io
+    # magic bytes
+    @test String(read(io, 4)) == "LASF"
     header = read(io, LasHeader)
 
     seek(io, header.data_offset)


### PR DESCRIPTION
Fixes #5

Do note that if you are on 0.6.0 you may get hanging for LAZ due to JuliaLang/julia#22832, which is fixed on master.

Currently there are no tests yet added for this, because for that to be possible `laszip` needs to be available on CI first.