### PR TITLE
[WIP] First DataStreams version

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,5 @@ ColorTypes 0.3.3
 FixedPointNumbers 0.3.2
 FileIO 0.3.0
 GeometryTypes 0.4.0
+DataStreams
+Parameters

--- a/src/LasIO.jl
+++ b/src/LasIO.jl
@@ -2,10 +2,12 @@ __precompile__()
 
 module LasIO
 
+using DataStreams
 using FileIO
 using FixedPointNumbers
 using ColorTypes
 using GeometryTypes # for conversion
+using Parameters
 
 export
     # Types
@@ -19,6 +21,7 @@ export
 
     # Functions on LasHeader
     update!,
+    pointtype,
 
     # Functions on LasPoint
     return_number,
@@ -52,6 +55,7 @@ include("point.jl")
 include("util.jl")
 include("fileio.jl")
 include("srs.jl")
+include("datastreams.jl")
 
 function __init__()
     # these should eventually go in

--- a/src/datastreams.jl
+++ b/src/datastreams.jl
@@ -1,0 +1,119 @@
+########
+# SOURCE
+########
+
+
+mutable struct Source <: Data.Source
+    schema::Data.Schema
+    header::LasHeader
+    io::IO
+    fullpath::String
+    datapos::Int
+end
+
+dict_of_struct(T) = Dict((String(fieldname(typeof(T), i)), getfield(T, i)) for i = 1:nfields(T))
+
+function Source(f::AbstractString)
+    # s = is_windows() ? open(f) : IOStream(Mmap.mmap(f))
+    io = open(f)
+
+    skiplasf(io)
+    header = read(io, LasHeader)
+
+    n = header.records_count
+    pointtype = pointformat(header)
+
+    # Schema
+    columns = Vector{String}(fieldnames(pointtype))
+    types = Vector{Type}([fieldtype(pointtype, i) for i in 1:nfields(pointtype)])
+    sch = Data.Schema(types, columns, n, dict_of_struct(header))
+
+    return Source(sch, header, io, f, position(io))
+end
+
+Data.reset!(s::LasIO.Source) = (seek(s.io, s.datapos); return nothing)
+Data.schema(source::LasIO.Source) = source.schema
+Data.accesspattern(::Type{LasIO.Source}) = Data.Sequential
+Data.isdone(source::LasIO.Source, row::Int, col::Int) = eof(source.io) || (row, col) > Data.size(Data.schema(source))
+Data.isdone(source::LasIO.Source, row, col, rows, cols) = eof(source.io) || row > rows || col > cols
+Data.streamtype(::Type{<:LasIO.Source}, ::Type{Data.Field}) = true
+
+# Data.streamfrom(source::LasIO.Source, st::Type{Data.Row}, t::Type{T}, row::Int) where {T} = read(source.io, pointformat(source.header))
+function Data.streamfrom(source::LasIO.Source, ::Type{Data.Field}, ::Type{T}, row::Int, col::Int) where {T}
+    # p = source.pointdata[row]
+    # v = getfield(p, fieldname(typeof(p), col))
+    read(source.io, T)
+end
+
+######
+# SINK
+######
+
+mutable struct Sink{T} <: Data.Sink where T <: LasPoint
+    stream::IO
+    header::LasHeader
+    # pointdata::Vector{T}
+    pointformat::Type{T}
+end
+
+# setup header and empty pointvector
+function Sink(sch::Data.Schema, S::Type{Data.Field}, append::Bool, fullpath::AbstractString)
+    s = open(fullpath, "w")
+
+    # determine point version and derivatives
+    pointtype = gettype(Data.header(sch))
+    data_format_id = pointformat(pointtype)
+    data_record_length = packed_size(pointtype)
+    n = Data.size(sch, 1)  # rows
+
+    # create header 
+    header = LasHeader(data_format_id=data_format_id, data_record_length=data_record_length, records_count=n)
+
+    # write header
+    write(s, magic(format"LAS"))
+    write(s, header)
+    println("Stream now at $(position(s))")
+
+    # create empty pointdata
+    # pointdata = Vector{pointtype}(n)
+
+    # return stream, position is correct for writing points
+    return Sink(s, header, pointtype)
+end
+
+# Update existing Sink
+# function Sink(sink::LasIO.Sink, sch::Data.Schema, S::Type{StreamType}, append::Bool; reference::Vector{UInt8}=UInt8[])
+    # return Sink
+# end
+
+"""Determine LAS versions based on specific columns."""
+function gettype(columns::Vector{String})
+    # LAS versions only differ in gps_time and rgb color information
+    has_gps, has_color = false, false
+    ("gps_time" in columns) && (has_gps = true)
+    ("red" in columns || "green" in columns || "blue" in columns) && (has_color = true)
+    
+    has_gps && has_color && return LasPoint3
+    has_color && return LasPoint2
+    has_gps && return LasPoint1
+    return LasPoint0
+end
+
+Data.streamtypes(::Type{LasIO.Sink}) = [Data.Field, Data.Row]
+Data.cleanup!(sink::LasIO.Sink) = nothing
+Data.weakrefstrings(::Type{LasIO.Sink}) = false
+
+# actually write points to our pointvector
+function Data.streamto!(sink::LasIO.Sink, S::Type{Data.Field}, val, row, col)
+    # TODO(evetion) check if stream position is at row*col
+    # write points
+    write(sink.stream, val)
+end
+
+# save file
+function Data.close!(sink::LasIO.Sink)
+    close(sink.stream)
+    # TODO(evetion) check number of points, extents etc
+    # change header if possible
+    return sink
+end

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -14,6 +14,20 @@ function pointformat(header::LasHeader)
     end
 end
 
+function pointformat(t::Type{T}) where T <: LasPoint
+    if t == LasPoint0
+        return 0x00
+    elseif t == LasPoint1
+        return 0x01
+    elseif t == LasPoint2
+        return 0x02
+    elseif t == LasPoint3
+        return 0x03
+    else
+        error("unsupported point format $t")
+    end
+end
+
 # skip the LAS file's magic four bytes, "LASF"
 skiplasf(s::Union{Stream{format"LAS"}, Stream{format"LAZ"}, IO}) = read(s, UInt32)
 
@@ -45,8 +59,7 @@ end
 
 function read_header(f::AbstractString)
     open(f) do s
-        skiplasf(s)
-        read(s, LasHeader)
+        read_header(s::IO)
     end
 end
 

--- a/src/header.jl
+++ b/src/header.jl
@@ -14,40 +14,40 @@ Backward compatibility with LAS 1.1 – LAS 1.3 when payloads consist of only le
 content
 =#
 
-mutable struct LasHeader
-    file_source_id::UInt16
-    global_encoding::UInt16
-    guid_1::UInt32
-    guid_2::UInt16
-    guid_3::UInt16
-    guid_4::AbstractString
-    version_major::UInt8
-    version_minor::UInt8
-    system_id::AbstractString
-    software_id::AbstractString
-    creation_doy::UInt16
-    creation_year::UInt16
-    header_size::UInt16
-    data_offset::UInt32
-    n_vlr::UInt32
-    data_format_id::UInt8
-    data_record_length::UInt16
-    records_count::UInt32
-    point_return_count::Vector{UInt32}
-    x_scale::Float64
-    y_scale::Float64
-    z_scale::Float64
-    x_offset::Float64
-    y_offset::Float64
-    z_offset::Float64
-    x_max::Float64
-    x_min::Float64
-    y_max::Float64
-    y_min::Float64
-    z_max::Float64
-    z_min::Float64
-    variable_length_records::Vector{LasVariableLengthRecord}
-    user_defined_bytes::Vector{UInt8}
+@with_kw mutable struct LasHeader
+    file_source_id::UInt16 = UInt16(0)  # no known flightline
+    global_encoding::UInt16 = UInt16(0)
+    guid_1::UInt32 = UInt32(0)  # project IDs
+    guid_2::UInt16 = UInt16(0)
+    guid_3::UInt16 = UInt16(0)
+    guid_4::AbstractString = rpad("", 8)
+    version_major::UInt8 = UInt8(1)
+    version_minor::UInt8 = UInt8(0)
+    system_id::AbstractString = rpad("LasIO.jl datastream", 32)  # small char array would be nicer
+    software_id::AbstractString = rpad("LasIO.jl", 32)
+    creation_doy::UInt16 = UInt16(Dates.dayofyear(now()))
+    creation_year::UInt16 = UInt16(Dates.year(now()))
+    header_size::UInt16 = UInt16(227)
+    data_offset::UInt32 = UInt32(227)
+    n_vlr::UInt32 = UInt32(0)
+    data_format_id::UInt8 = UInt8(pointformat(LasPoint0))
+    data_record_length::UInt16 = UInt16(packed_size(LasPoint0))
+    records_count::UInt32 = UInt32(0)
+    point_return_count::Vector{UInt32} = Vector{UInt32}([0,0,0,0,0])
+    x_scale::Float64 = 0.01
+    y_scale::Float64 = 0.01
+    z_scale::Float64 = 0.01
+    x_offset::Float64 = 0.0
+    y_offset::Float64 = 0.0
+    z_offset::Float64 = 0.0
+    x_max::Float64 = 0.0
+    x_min::Float64 = 0.0
+    y_max::Float64 = 0.0
+    y_min::Float64 = 0.0
+    z_max::Float64 = 0.0
+    z_min::Float64 = 0.0
+    variable_length_records::Vector{LasVariableLengthRecord} = Vector{LasVariableLengthRecord}()
+    user_defined_bytes::Vector{UInt8} = Vector{UInt8}()
 end
 
 function Base.show(io::IO, header::LasHeader)

--- a/src/point.jl
+++ b/src/point.jl
@@ -8,64 +8,68 @@ function Base.show(io::IO, pointdata::Vector{T}) where T <: LasPoint
 end
 
 "ASPRS LAS point data record format 0"
-struct LasPoint0 <: LasPoint
+@with_kw struct LasPoint0 <: LasPoint
     x::Int32
     y::Int32
     z::Int32
-    intensity::UInt16
-    flag_byte::UInt8
-    raw_classification::UInt8
-    scan_angle::Int8
-    user_data::UInt8
-    pt_src_id::UInt16
+    intensity::UInt16 = UInt16(0)
+    flag_byte::UInt8 = 0x0
+    raw_classification::UInt8 = 0x0
+    scan_angle::Int8 = Int8(0)
+    user_data::UInt8 = 0x0
+    pt_src_id::UInt16 = UInt16(0)
 end
+packed_size(::Type{LasPoint0}) = 20
 
 "ASPRS LAS point data record format 1"
-struct LasPoint1 <: LasPoint
+@with_kw struct LasPoint1 <: LasPoint
     x::Int32
     y::Int32
     z::Int32
-    intensity::UInt16
-    flag_byte::UInt8
-    raw_classification::UInt8
-    scan_angle::Int8
-    user_data::UInt8
-    pt_src_id::UInt16
-    gps_time::Float64
+    intensity::UInt16 = UInt16(0)
+    flag_byte::UInt8 = 0x0
+    raw_classification::UInt8 = 0x0
+    scan_angle::Int8 = Int8(0)
+    user_data::UInt8 = 0x0
+    pt_src_id::UInt16 = UInt16(0)
+    gps_time::Float64 = gps_time(now())
 end
+packed_size(::Type{LasPoint1}) = 28
 
 "ASPRS LAS point data record format 2"
-struct LasPoint2 <: LasPoint
+@with_kw struct LasPoint2 <: LasPoint
     x::Int32
     y::Int32
     z::Int32
-    intensity::UInt16
-    flag_byte::UInt8
-    raw_classification::UInt8
-    scan_angle::Int8
-    user_data::UInt8
-    pt_src_id::UInt16
-    red::N0f16
-    green::N0f16
-    blue::N0f16
+    intensity::UInt16 = UInt16(0)
+    flag_byte::UInt8 = 0x0
+    raw_classification::UInt8 = 0x0
+    scan_angle::Int8 = Int8(0)
+    user_data::UInt8 = 0x0
+    pt_src_id::UInt16 = UInt16(0)
+    red::N0f16 = N0f16(0)
+    green::N0f16 = N0f16(0)
+    blue::N0f16 = N0f16(0)
 end
+packed_size(::Type{LasPoint2}) = 26
 
 "ASPRS LAS point data record format 3"
-struct LasPoint3 <: LasPoint
+@with_kw struct LasPoint3 <: LasPoint
     x::Int32
     y::Int32
     z::Int32
-    intensity::UInt16
-    flag_byte::UInt8
-    raw_classification::UInt8
-    scan_angle::Int8
-    user_data::UInt8
-    pt_src_id::UInt16
-    gps_time::Float64
-    red::N0f16
-    green::N0f16
-    blue::N0f16
+    intensity::UInt16 = UInt16(0)
+    flag_byte::UInt8 = 0x0
+    raw_classification::UInt8 = 0x0
+    scan_angle::Int8 = Int8(0)
+    user_data::UInt8 = 0x0
+    pt_src_id::UInt16 = UInt16(0)
+    gps_time::Float64 = gps_time(now())
+    red::N0f16 = N0f16(0)
+    green::N0f16 = N0f16(0)
+    blue::N0f16 = N0f16(0)
 end
+packed_size(::Type{LasPoint3}) = 34
 
 # for convenience in function signatures
 const LasPointColor = Union{LasPoint2,LasPoint3}


### PR DESCRIPTION
Work in progress:
- Writing only works with Source columns that match a LasPoint perfectly
- [ ] Conversion XYZ Float to Int32 (determine scaling/offset) needs to be implemented
- [ ] Header statistics needs to be updated after streaming

What works:

```julia
julia> s = LasIO.Source("test/srs.las")
LasIO.Source(Data.Schema:
rows: 10  cols: 10
Columns:
 "x"                   Int32  
 "y"                   Int32  
 "z"                   Int32  
 "intensity"           UInt16 
 "flag_byte"           UInt8  
 "raw_classification"  UInt8  
 "scan_angle"          Int8   
 "user_data"           UInt8  
 "pt_src_id"           UInt16 
 "gps_time"            Float64, LasHeader with 10 points.
, IOStream(<file test/srs.las>), "test/srs.las", 759)

julia> d = Data.stream!(s, DataFrame)
DataFrames.DataFrameStream{Tuple{Array{Int32,1},Array{Int32,1},Array{Int32,1},Array{UInt16,1},Array{UInt8,1},Array{UInt8,1},Array{Int8,1},Array{UInt8,1},Array{UInt16,1},Array{Float64,1}}}((Int32[28981415, 28981464, 28981512, 28981560, 28981608, 28981656, 28981703, 28981753, 28981801, 28981850], Int32[432097861, 432097884, 432097906, 432097928, 432097950, 432097971, 432097992, 432098016, 432098038, 432098059], Int32[17076, 17076, 17075, 17074, 17068, 17066, 17063, 17062, 17061, 17058], UInt16[0x0104, 0x0118, 0x0118, 0x0118, 0x0104, 0x00f0, 0x00f0, 0x0118, 0x0118, 0x0104], UInt8[0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30], UInt8[0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02], Int8[0, 0, 0, 0, 0, 0, 0, 0, 0, 0], UInt8[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], UInt16[0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000], [4.99451e5, 4.99451e5, 4.99451e5, 4.99451e5, 4.99451e5, 4.99451e5, 4.99451e5, 4.99451e5, 4.99451e5, 4.99451e5]), String["x", "y", "z", "intensity", "flag_byte", "raw_classification", "scan_angle", "user_data", "pt_src_id", "gps_time"])

julia> Data.close!(d)
10×10 DataFrames.DataFrame
│ Row │ x        │ y         │ z     │ intensity │ flag_byte │ raw_classification │ scan_angle │ user_data │ pt_src_id │ gps_time  │
├─────┼──────────┼───────────┼───────┼───────────┼───────────┼────────────────────┼────────────┼───────────┼───────────┼───────────┤
│ 1   │ 28981415 │ 432097861 │ 17076 │ 0x0104    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 2   │ 28981464 │ 432097884 │ 17076 │ 0x0118    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 3   │ 28981512 │ 432097906 │ 17075 │ 0x0118    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 4   │ 28981560 │ 432097928 │ 17074 │ 0x0118    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 5   │ 28981608 │ 432097950 │ 17068 │ 0x0104    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 6   │ 28981656 │ 432097971 │ 17066 │ 0x00f0    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 7   │ 28981703 │ 432097992 │ 17063 │ 0x00f0    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 8   │ 28981753 │ 432098016 │ 17062 │ 0x0118    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 9   │ 28981801 │ 432098038 │ 17061 │ 0x0118    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │
│ 10  │ 28981850 │ 432098059 │ 17058 │ 0x0104    │ 0x30      │ 0x02               │ 0          │ 0x00      │ 0x0000    │ 4.99451e5 │

julia> Data.reset!(s)

julia> d = Data.stream!(s, LasIO.Sink, "test_final.las")
Stream now at 227
LasIO.Sink{LasIO.LasPoint1}(IOStream(<file test_final.las>), LasHeader with 10 points.
, LasIO.LasPoint1)

julia> Data.close!(d)
LasIO.Sink{LasIO.LasPoint1}(IOStream(<file test_final.las>), LasHeader with 10 points.
, LasIO.LasPoint1)
```

```bash
➜ lasinfo test_final.las 
lasinfo (170528) report for test_final.las
reporting all LAS header entries:
  file signature:             'LASF'
  file source ID:             0
  global_encoding:            0
  project ID GUID data 1-4:   00000000-0000-0000-2020-202020202020
  version major.minor:        1.0
  system identifier:          'LasIO.jl datastream             '
  generating software:        'LasIO.jl                        '
  file creation day/year:     10/2018
  header size:                227
  offset to point data:       227
  number var. length records: 0
  point data format:          1
  point data record length:   28
  number of point records:    10
  number of points by return: 0 0 0 0 0
  scale factor x y z:         0.01 0.01 0.01
  offset x y z:               0 0 0
  min x y z:                  0.00 0.00 0.00
  max x y z:                  0.00 0.00 0.00
reporting minimum and maximum for all LAS point record entries ...
  X            28981415   28981850
  Y           432097861  432098059
  Z               17058      17076
  intensity         240        280
  return_number       0          0
  number_of_returns   6          6
  edge_of_flight_line 0          0
  scan_direction_flag 0          0
  classification      2          2
  scan_angle_rank     0          0
  user_data           0          0
  point_source_ID     0          0
  gps_time 499450.805994 499450.806120
WARNING: 10 points outside of header bounding box
number of first returns:        10
number of intermediate returns: 0
number of last returns:         0
number of single returns:       0
WARNING: there are 10 points with return number 0
overview over number of returns of given pulse: 0 0 0 0 0 10 0
histogram of classification of points:
              10  ground (2)
real max x larger than header max x by 289818.500000
real max y larger than header max y by 4320980.590000
real max z larger than header max z by 170.760000```