### PR TITLE
update type signature for piped LAZ

### DIFF
--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -25,7 +25,7 @@ function load(f::File{format"LAS"}; mmap=false)
 end
 
 # Load pipe separately since it can't be memory mapped
-function load(s::Pipe)
+function load(s::Base.AbstractPipe)
     skiplasf(s)
     header = read(s, LasHeader)
 


### PR DESCRIPTION
it seems that in julia 0.7+ a Process is returned, which is a AbstractPipe