### PR TITLE
Renamed and deprecated header field doy to day of year.

### DIFF
--- a/src/header.jl
+++ b/src/header.jl
@@ -52,7 +52,7 @@ end
 
 function Base.getproperty(h::LasHeader, s::Symbol)
     if s == :creation_doy
-        @warn "$s is deprecated, use :creation_dayofyear instead."
+        Base.depwarn("LasHeader.creation_doy is deprecated, use LasHeader.creation_dayofyear", :getproperty)
         return getfield(h, :creation_dayofyear)
     else
         return getfield(h, s)


### PR DESCRIPTION
Fixes #20 
Second commit also removes all usage of doy itself, so example below won't happen.

```julia
julia> h, p = load("test/libLAS_1.2.las")
(LasHeader with 497536 points.
	file_source_id = 0
	global_encoding = 0
	guid_1 = 0
	guid_2 = 0
	guid_3 = 0
	guid_4 =
	version_major = 1
	version_minor = 2
	system_id = MODIFICATION
	software_id = TerraScan
┌ Warning: creation_doy is deprecated, use :creation_dayofyear instead.
└ @ LasIO ~/.julia/dev/LasIO/src/header.jl:55
	creation_doy = 0
	creation_year = 0
	header_size = 227
	data_offset = 227
	n_vlr = 0
	data_format_id = 0
	data_record_length = 20
	records_count = 497536
	point_return_count = UInt32[0x00079780, 0x00000000, 0x00000000, 0x00000000, 0x00000000]
	x_scale = 0.01
	y_scale = 0.01
	z_scale = 0.01
	x_offset = -0.0
	y_offset = -0.0
	z_offset = -0.0
	x_max = 1.44499996e6
	x_min = 1.44e6
	y_max = 379999.99
	y_min = 375000.03
	z_max = 972.6700000000001
	z_min = 832.1800000000001
, Array{LasPoint0,1} with 497536 points.
)
```