### PR TITLE
add scaled_boundingbox function

### DIFF
--- a/src/LasIO.jl
+++ b/src/LasIO.jl
@@ -23,7 +23,6 @@ export
     update!,
     pointformat,
     boundingbox,
-    scaled_boundingbox,
 
     # Functions on LasPoint
     return_number,

--- a/src/LasIO.jl
+++ b/src/LasIO.jl
@@ -23,6 +23,7 @@ export
     update!,
     pointformat,
     boundingbox,
+    scaled_boundingbox,
 
     # Functions on LasPoint
     return_number,

--- a/src/header.jl
+++ b/src/header.jl
@@ -279,3 +279,12 @@ end
 "Retrieve the bounding box from a LasHeader as a NamedTuple"
 boundingbox(h::LasHeader) = (xmin = h.x_min, ymin = h.y_min, zmin = h.z_min,
     xmax = h.x_max, ymax = h.y_max, zmax = h.z_max)
+
+scaled_boundingbox(h::LasHeader) = (
+    xmin = (h.x_min - h.x_offset) / h.x_scale,
+    ymin = (h.y_min - h.y_offset) / h.y_scale,
+    zmin = (h.z_min - h.z_offset) / h.z_scale,
+    xmax = (h.x_max - h.x_offset) / h.x_scale,
+    ymax = (h.y_max - h.y_offset) / h.y_scale,
+    zmax = (h.z_max - h.z_offset) / h.z_scale
+)

--- a/src/header.jl
+++ b/src/header.jl
@@ -280,11 +280,12 @@ end
 boundingbox(h::LasHeader) = (xmin = h.x_min, ymin = h.y_min, zmin = h.z_min,
     xmax = h.x_max, ymax = h.y_max, zmax = h.z_max)
 
-scaled_boundingbox(h::LasHeader) = (
-    xmin = (h.x_min - h.x_offset) / h.x_scale,
-    ymin = (h.y_min - h.y_offset) / h.y_scale,
-    zmin = (h.z_min - h.z_offset) / h.z_scale,
-    xmax = (h.x_max - h.x_offset) / h.x_scale,
-    ymax = (h.y_max - h.y_offset) / h.y_scale,
-    zmax = (h.z_max - h.z_offset) / h.z_scale
+"Get the boundingbox in the same stored integer form as the raw point coordinates"
+boundingbox_unscaled(h::LasHeader) = (
+    xmin = round(Int32, (h.x_min - h.x_offset) / h.x_scale),
+    ymin = round(Int32, (h.y_min - h.y_offset) / h.y_scale),
+    zmin = round(Int32, (h.z_min - h.z_offset) / h.z_scale),
+    xmax = round(Int32, (h.x_max - h.x_offset) / h.x_scale),
+    ymax = round(Int32, (h.y_max - h.y_offset) / h.y_scale),
+    zmax = round(Int32, (h.z_max - h.z_offset) / h.z_scale)
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,3 +138,5 @@ rm(srsfile_out)
 
 @test boundingbox(header) === (xmin = 1.44e6, ymin = 375000.03, zmin = 832.1800000000001,
     xmax = 1.44499996e6, ymax = 379999.99, zmax = 972.6700000000001)
+
+@test scaled_boundingbox(header) === (xmin = 1.44e8, ymin = 3.7500003e7, zmin = 83218.0, xmax = 1.44499996e8, ymax = 3.7999999e7, zmax = 97267.0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,5 +138,4 @@ rm(srsfile_out)
 
 @test boundingbox(header) === (xmin = 1.44e6, ymin = 375000.03, zmin = 832.1800000000001,
     xmax = 1.44499996e6, ymax = 379999.99, zmax = 972.6700000000001)
-
-@test scaled_boundingbox(header) === (xmin = 1.44e8, ymin = 3.7500003e7, zmin = 83218.0, xmax = 1.44499996e8, ymax = 3.7999999e7, zmax = 97267.0)
+@test LasIO.boundingbox_unscaled(header) === (xmin = Int32(144000000), ymin = Int32(37500003), zmin = Int32(83218), xmax = Int32(144499996), ymax = Int32(37999999), zmax = Int32(97267))


### PR DESCRIPTION
this adds a `scaled_boundingbox` function as discussed [here](https://github.com/Deltares/PointCloudRasterizers.jl/issues/7).