### PR TITLE
add @sprintf statements to improve printing consistency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 GeometryTypes = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
 ColorTypes = "0.7, 0.8, 0.9, 0.10"

--- a/src/header.jl
+++ b/src/header.jl
@@ -1,3 +1,4 @@
+using Printf
 # the header implemented based on LAS 1.2
 # TODO: check compatibility other LAS versions
 
@@ -87,12 +88,12 @@ function Base.show(io::IO, header::LasHeader)
     println(io, string("\tx_offset = ", header.x_offset))
     println(io, string("\ty_offset = ", header.y_offset))
     println(io, string("\tz_offset = ", header.z_offset))
-    println(io, string("\tx_max = ", header.x_max))
-    println(io, string("\tx_min = ", header.x_min))
-    println(io, string("\ty_max = ", header.y_max))
-    println(io, string("\ty_min = ", header.y_min))
-    println(io, string("\tz_max = ", header.z_max))
-    println(io, string("\tz_min = ", header.z_min))
+    println(io, @sprintf "\tx_max = %.7f" header.x_max)
+    println(io, @sprintf "\tx_min = %.7f" header.x_min)
+    println(io, @sprintf "\ty_max = %.7f" header.y_max)
+    println(io, @sprintf "\ty_min = %.7f" header.y_min)
+    println(io, @sprintf "\tz_max = %.7f" header.z_max)
+    println(io, @sprintf "\tz_min = %.7f" header.z_min)
 
     if !isempty(header.variable_length_records)
         nrecords = min(10, size(header.variable_length_records, 1))


### PR DESCRIPTION
Currently the header files can print an inconsistent mix of scientific and standard notation depending on the source file.

Before:
```
using FileIO, LasIO
header, points = load("libLAS_1.2.las")

LasHeader with 497536 points.
#...stuff...
        x_max = 1.44499996e6
        x_min = 1.44e6
        y_max = 379999.99
        y_min = 375000.03
        z_max = 972.6700000000001
        z_min = 832.1800000000001
```

This PR modifies the `Base.show` to ensure a consistent format for the min/max fields. I don't think the other fields would have this issue.

After:
```
julia> header1, points1 = load("libLAS_1.2.las")
(LasHeader with 497536 points.
 #..stuff..
        x_max = 1444999.9600000
        x_min = 1440000.0000000
        y_max = 379999.9900000
        y_min = 375000.0300000
        z_max = 972.6700000
        z_min = 832.1800000
```
Note:
This does add `Printf`as a dependency to the `Project.TOML` but I thought it would be reasonable since it's part of the standard library. 
